### PR TITLE
Bugfix: prettier svelte

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "npm run check:svelte && npm run check:lint && npm run check:format && npm run test",
-    "check:format": "prettier --write .",
+    "check:format": "prettier --plugin-search-dir . --write .",
     "check:lint": "eslint .",
     "check:svelte": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "test": "npm run test:integration && npm run test:unit",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
-<div class="prose dark:prose-invert p-8 mx-auto">
+<div class="prose mx-auto p-8 dark:prose-invert">
   <h1>Hi there!</h1>
   <p>
-    My name is Tucker and this is my website. Things are still under construction... but stay tuned for more updates!
+    My name is Tucker and this is my website. Things are still under construction... but stay tuned
+    for more updates!
   </p>
 </div>

--- a/src/routes/Navbar.svelte
+++ b/src/routes/Navbar.svelte
@@ -6,35 +6,39 @@
 
 <AppBar background="bg-primary-500 dark:bg-surface-800 text-on-primary-token">
   <svelte:fragment slot="lead">
-    <a href="/" class="flex items-center mr-8">
-      <img src="/mustachioed-favicon.png" alt="Tucker Emoji" class="h-8 mr-4" />
+    <a href="/" class="mr-8 flex items-center">
+      <img src="/mustachioed-favicon.png" alt="Tucker Emoji" class="mr-4 h-8" />
       <b>{config.title}</b>
     </a>
     <a href="/blog">Blog</a>
   </svelte:fragment>
   <svelte:fragment slot="trail">
     <a
-      class="btn-icon hover:variant-soft-primary !ml-0 hover:text-on-primary-token"
+      class="btn-icon !ml-0 hover:variant-soft-primary hover:text-on-primary-token"
       href="https://github.com/tuckergordon/website"
       target="_blank"
       rel="noreferrer">
       <Icon icon="fa-brands:github" />
     </a>
     <a
-      class="btn-icon hover:variant-soft-primary !ml-0 hover:text-on-primary-token"
+      class="btn-icon !ml-0 hover:variant-soft-primary hover:text-on-primary-token"
       href="https://www.linkedin.com/in/tucker-gordon-ab5b8b67/"
       target="_blank"
       rel="noreferrer">
       <Icon icon="fa-brands:linkedin" />
     </a>
     <a
-      class="btn-icon hover:variant-soft-primary !ml-0 hover:text-on-primary-token"
+      class="btn-icon !ml-0 hover:variant-soft-primary hover:text-on-primary-token"
       href="https://twitter.com/TuckerAGordon"
       target="_blank"
       rel="noreferrer">
       <Icon icon="fa-brands:twitter" />
     </a>
-    <a class="btn-icon hover:variant-soft-primary !ml-0 hover:text-on-primary-token" href="/rss.xml" target="_blank" rel="noreferrer">
+    <a
+      class="btn-icon !ml-0 hover:variant-soft-primary hover:text-on-primary-token"
+      href="/rss.xml"
+      target="_blank"
+      rel="noreferrer">
       <Icon icon="fa-solid:rss" />
     </a>
     <LightSwitch rounded="rounded-full" />

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -12,7 +12,7 @@
 
 <div class="container mx-auto my-4">
   <h1 class="h1 my-8">Blog</h1>
-  <section class="grid grid-cols-2 md:grid-cols-3 gap-4">
+  <section class="grid grid-cols-2 gap-4 md:grid-cols-3">
     {#each data.posts as post}
       <PostCard {post} />
     {/each}

--- a/src/routes/blog/PostCard.svelte
+++ b/src/routes/blog/PostCard.svelte
@@ -5,7 +5,9 @@
   export let post: Post;
 </script>
 
-<a href="blog/{post.slug}" class="p-4 h-auto min-h-[300px] max-w-full card rounded-lg prose dark:prose-invert">
+<a
+  href="blog/{post.slug}"
+  class="prose card h-auto min-h-[300px] max-w-full rounded-lg p-4 dark:prose-invert">
   <h2>{post.title}</h2>
   <p>{formatDate(post.date)}</p>
   <p>{post.description}</p>

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -11,7 +11,7 @@
   <meta property="og:title" content={data.meta.title} />
 </svelte:head>
 
-<article class="prose dark:prose-invert mx-auto p-4 pt-12">
+<article class="prose mx-auto p-4 pt-12 dark:prose-invert">
   <hgroup>
     <h1>{data.meta.title}</h1>
     <p class="italic">{formatDate(data.meta.date)}</p>


### PR DESCRIPTION
Prettier wasn't actually formatting .svelte files because it was missing the `--plugin-search-dir .` arg. This commit fixes the issue and includes missing changes.