### PR TITLE
Added hamburger menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:unit:watch": "vitest"
   },
   "devDependencies": {
+    "@floating-ui/dom": "^1.5.0",
     "@fontsource-variable/outfit": "^5.0.5",
     "@iconify/svelte": "^3.1.4",
     "@playwright/test": "^1.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 devDependencies:
+  '@floating-ui/dom':
+    specifier: ^1.5.0
+    version: 1.5.0
   '@fontsource-variable/outfit':
     specifier: ^5.0.5
     version: 5.0.5
@@ -466,6 +469,23 @@ packages:
   /@eslint/js@8.44.0:
     resolution: {integrity: sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@floating-ui/core@1.4.0:
+    resolution: {integrity: sha512-x5Ly1Eiyqt9aR38XzhraoWxgtQtvy3mVChWMZIr49XFyvIhNuqUxZKXBRoI5WiMRaaAZezCauJaEISu3z5y8sg==}
+    dependencies:
+      '@floating-ui/utils': 0.1.0
+    dev: true
+
+  /@floating-ui/dom@1.5.0:
+    resolution: {integrity: sha512-9jPin5dTlcEN+nXzBRhdreCzlJBIYWeMXpJJ5VnO1l9dLcP7uQNPbmwmIoHpHpH6GPYMYtQA7GfkvsSj/CQPwg==}
+    dependencies:
+      '@floating-ui/core': 1.4.0
+      '@floating-ui/utils': 0.1.0
+    dev: true
+
+  /@floating-ui/utils@0.1.0:
+    resolution: {integrity: sha512-ZSlli/beGZdvoqT3/Y9oOW79XSEpBfxt8UY6vjyWJW0B8d/M+MKlkQ3kBzLKDXaSsB84IVj6QntQfHLzesB4mA==}
     dev: true
 
   /@fontsource-variable/outfit@5.0.5:

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { page } from '$app/stores';
+  import { computePosition, autoUpdate, offset, shift, flip, arrow } from '@floating-ui/dom';
   import '@fontsource-variable/outfit';
   import { AppShell } from '@skeletonlabs/skeleton';
+  import { storePopup } from '@skeletonlabs/skeleton';
   import '@skeletonlabs/skeleton/styles/skeleton.css';
 
   import '../styles/app.postcss';
@@ -16,6 +18,9 @@
 
   $: showSidenavs = $page.url.pathname.includes('/blog/');
   $: sidebarClasses = showSidenavs ? 'w-0 lg:w-64' : 'hidden';
+
+  // Setup Skeleton pop-up for use throughout the app
+  storePopup.set({ computePosition, autoUpdate, offset, shift, flip, arrow });
 </script>
 
 <AppShell slotSidebarLeft={sidebarClasses} slotSidebarRight={sidebarClasses}>

--- a/src/routes/Navbar.svelte
+++ b/src/routes/Navbar.svelte
@@ -4,10 +4,10 @@
   import { AppBar, LightSwitch, popup, type PopupSettings } from '@skeletonlabs/skeleton';
 
   const popupCombobox: PopupSettings = {
-    event: 'focus-click',
+    event: 'click',
     target: 'popupCombobox',
     placement: 'bottom',
-    closeQuery: '.listbox-item',
+    closeQuery: '.list-nav a',
   };
 
   const links = [

--- a/src/routes/Navbar.svelte
+++ b/src/routes/Navbar.svelte
@@ -1,21 +1,65 @@
 <script lang="ts">
   import * as config from '$lib/config';
   import Icon from '@iconify/svelte';
-  import { AppBar, LightSwitch } from '@skeletonlabs/skeleton';
+  import { AppBar, LightSwitch, popup, type PopupSettings } from '@skeletonlabs/skeleton';
+
+  const popupCombobox: PopupSettings = {
+    event: 'focus-click',
+    target: 'popupCombobox',
+    placement: 'bottom',
+    closeQuery: '.listbox-item',
+  };
+
+  const links = [
+    {
+      name: 'Blog',
+      href: '/blog',
+    },
+    // More links go here
+  ];
 </script>
 
 <AppBar background="bg-primary-500 dark:bg-surface-800 text-on-primary-token">
-  <!-- TODO: implement hamburger menu on xs -->
   <svelte:fragment slot="lead">
-    <a href="/" class="mr-4 flex items-center sm:mr-8">
+    <button
+      class="btn-icon hover:variant-soft-primary hover:text-on-primary-token sm:!hidden"
+      use:popup={popupCombobox}>
+      <Icon icon="fa-bars" />
+    </button>
+
+    <!-- Hamburger menu -->
+    <div
+      class="card w-48 bg-primary-400 py-2 shadow-xl dark:bg-surface-700"
+      data-popup="popupCombobox">
+      <nav class="list-nav">
+        <ul>
+          {#each links as link}
+            <li>
+              <a href={link.href} class="!rounded-none">
+                <span class="flex-auto">{link.name}</span>
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </nav>
+      <div class="arrow bg-inherit" />
+    </div>
+
+    <a href="/" class="flex items-center sm:mr-8">
       <img src="/mustachioed-favicon.png" alt="Tucker Emoji" class="mr-4 h-8" />
       <b>{config.title}</b>
     </a>
-    <a href="/blog">Blog</a>
   </svelte:fragment>
   <svelte:fragment slot="trail">
+    {#each links as link}
+      <a
+        href={link.href}
+        class="btn hidden hover:variant-soft-surface hover:text-on-primary-token sm:block">
+        {link.name}
+      </a>
+    {/each}
     <a
-      class="btn-icon hidden hover:variant-soft-primary hover:text-on-primary-token sm:flex"
+      class="btn-icon !mx-0 hover:variant-soft-surface hover:text-on-primary-token"
       href="https://github.com/tuckergordon/website"
       target="_blank"
       rel="noreferrer">


### PR DESCRIPTION
Closes #17 by adding a hamburger menu to the Navbar which appears when on `sm` and smaller screenwidths in place of the links. The GitHub link and theme switcher will always appear, but the rest of the links will get collapsed down.

Also moved the nav links to the right side to give them more room.