### PR TITLE
Update blog styles

### DIFF
--- a/src/lib/components/Scroller/Scroller.svelte
+++ b/src/lib/components/Scroller/Scroller.svelte
@@ -64,13 +64,15 @@
 
 <style lang="scss">
   .scroller {
+    $header-height: 75px;
+
     position: relative;
     width: 100vw;
 
     &-backdrop {
       position: sticky;
-      top: 0;
-      height: calc(100vh - 75px); // TODO: dynamic based on nav bar height
+      top: $header-height;
+      height: calc(100vh - $header-height);
       width: 100%;
       overflow: hidden;
 
@@ -84,7 +86,7 @@
     &-overlays {
       width: 100%;
       min-height: 100vh;
-      margin-top: -100vh; // TODO: be able to explain this
+      margin-top: -100vh;
       // fixes a safari z-index bug where some overlays go behind the backdrop
       transform: translate3d(0, 0, 0);
       // lets you interact with the backdrop

--- a/src/posts/dev-setup.md
+++ b/src/posts/dev-setup.md
@@ -25,7 +25,7 @@ Here's how I make the Mac terminal look/work the way I want
 - [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) - a gamechanger. Way
   better than recursive searching.
   - To install:
-    - `brew install zsh-autosuggestions``
+    - `brew install zsh-autosuggestions`
     - Add `source /usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh` to `~/.zshrc`
 
 ## Environment Management

--- a/src/posts/standalone-angular.md
+++ b/src/posts/standalone-angular.md
@@ -145,7 +145,3 @@ To use this script, add a new command to `package.json`:
 
 Then you can simply run `npm run build:standalone`. The `dist/standalone/` directory will contain a
 standalone application that can be run by double-clicking the `index.html` file.
-
-### Vue
-
-<!-- TODO: -->

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,45 +1,26 @@
 <script lang="ts">
-  import { page } from '$app/state';
+  import { afterNavigate } from '$app/navigation';
   import '../styles/app.postcss';
   import Footer from './Footer.svelte';
   import Navbar from './Navbar.svelte';
-  import Transition from './Transition.svelte';
-  import BlogSideToc from './blog/SideToc.svelte';
-  import BlogSidenav from './blog/Sidenav.svelte';
   import { computePosition, autoUpdate, offset, shift, flip, arrow } from '@floating-ui/dom';
   import '@fontsource-variable/outfit';
-  import { AppShell } from '@skeletonlabs/skeleton';
   import { storePopup } from '@skeletonlabs/skeleton';
 
-  let { data, children } = $props();
-
-  let showSidenavs = $derived(page.url.pathname.includes('/blog/'));
-  let sidebarClasses = $derived(showSidenavs ? 'w-0 lg:w-64' : 'hidden');
+  let { children } = $props();
 
   // Setup Skeleton pop-up for use throughout the app
   storePopup.set({ computePosition, autoUpdate, offset, shift, flip, arrow });
+
+  // Workaround to ensure page goes back to the top when navigating
+  // between routes. More info: https://github.com/sveltejs/kit/issues/2733#issuecomment-1543863772
+  afterNavigate(() => {
+    document.body.scrollTo(0, 0);
+  });
 </script>
 
-<AppShell slotSidebarLeft={sidebarClasses} slotSidebarRight={sidebarClasses}>
-  {#snippet header()}
-    <Navbar />
-  {/snippet}
-  {#snippet sidebarLeft()}
-    {#if showSidenavs}
-      <BlogSidenav />
-    {/if}
-  {/snippet}
-  {#snippet sidebarRight()}
-    {#if showSidenavs}
-      <BlogSideToc />
-    {/if}
-  {/snippet}
-
-  <Transition url={data.url}>
-    {@render children?.()}
-  </Transition>
-
-  {#snippet pageFooter()}
-    <Footer />
-  {/snippet}
-</AppShell>
+<div class="grid min-h-screen grid-rows-[auto_1fr_auto]">
+  <Navbar />
+  {@render children?.()}
+  <Footer />
+</div>

--- a/src/routes/Navbar.svelte
+++ b/src/routes/Navbar.svelte
@@ -12,64 +12,69 @@
 
   const links = [
     {
-      name: 'About',
+      name: 'Home',
       href: '/',
     },
     {
       name: 'Blog',
       href: '/blog',
     },
-    // More links go here
+    // {
+    //   name: 'Projects',
+    //   href: '/projects',
+    // },
   ];
 </script>
 
-<AppBar background="bg-primary-500 dark:bg-surface-800 text-on-primary-token">
-  {#snippet lead()}
-    <button
-      class="btn-icon hover:variant-soft-primary hover:text-on-primary-token sm:!hidden"
-      use:popup={popupCombobox}>
-      <Icon icon="fa-bars" />
-    </button>
+<header class="sticky top-0 z-10">
+  <AppBar background="bg-primary-500 dark:bg-surface-800 text-on-primary-token">
+    {#snippet lead()}
+      <button
+        class="btn-icon hover:variant-soft-primary hover:text-on-primary-token sm:!hidden"
+        use:popup={popupCombobox}>
+        <Icon icon="fa-bars" />
+      </button>
 
-    <!-- Hamburger menu -->
-    <div
-      class="card w-48 bg-primary-400 py-2 shadow-xl dark:bg-surface-700"
-      data-popup="popupCombobox">
-      <nav class="list-nav">
-        <ul>
-          {#each links as link}
-            <li>
-              <a href={link.href} class="!rounded-none">
-                <span class="flex-auto">{link.name}</span>
-              </a>
-            </li>
-          {/each}
-        </ul>
-      </nav>
-      <div class="arrow bg-inherit"></div>
-    </div>
+      <!-- Hamburger menu -->
+      <div
+        class="card w-48 bg-primary-400 py-2 shadow-xl dark:bg-surface-700"
+        data-popup="popupCombobox">
+        <nav class="list-nav">
+          <ul>
+            {#each links as link}
+              <li>
+                <a href={link.href} class="!rounded-none">
+                  <span class="flex-auto">{link.name}</span>
+                </a>
+              </li>
+            {/each}
+          </ul>
+        </nav>
+        <div class="arrow bg-inherit"></div>
+      </div>
 
-    <a href="/" class="flex items-center sm:mr-8">
-      <!-- svelte-preprocess-import-assets-ignore -->
-      <img src="/images/mustachioed-favicon.png" alt="Tucker Emoji" class="mr-4 h-8" />
-      <b>{config.title}</b>
-    </a>
-  {/snippet}
-  {#snippet trail()}
-    {#each links as link}
-      <a
-        href={link.href}
-        class="btn !mx-0 hidden hover:variant-soft-surface hover:text-on-primary-token sm:block">
-        {link.name}
+      <a href="/" class="flex items-center sm:mr-8">
+        <!-- svelte-preprocess-import-assets-ignore -->
+        <img src="/images/mustachioed-favicon.png" alt="Tucker Emoji" class="mr-4 h-8" />
+        <b>{config.title}</b>
       </a>
-    {/each}
-    <a
-      class="btn-icon !mx-0 hover:variant-soft-surface hover:text-on-primary-token"
-      href="https://github.com/tuckergordon/website"
-      target="_blank"
-      rel="noreferrer">
-      <Icon icon="fa-brands:github" />
-    </a>
-    <LightSwitch rounded="rounded-full" />
-  {/snippet}
-</AppBar>
+    {/snippet}
+    {#snippet trail()}
+      {#each links as link}
+        <a
+          href={link.href}
+          class="btn !mx-0 hidden hover:variant-soft-surface hover:text-on-primary-token sm:block">
+          {link.name}
+        </a>
+      {/each}
+      <a
+        class="btn-icon !mx-0 hover:variant-soft-surface hover:text-on-primary-token"
+        href="https://github.com/tuckergordon/website"
+        target="_blank"
+        rel="noreferrer">
+        <Icon icon="fa-brands:github" />
+      </a>
+      <LightSwitch rounded="rounded-full" />
+    {/snippet}
+  </AppBar>
+</header>

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -9,9 +9,9 @@
   <title>{config.title} | Blog</title>
 </svelte:head>
 
-<div class="container px-4 sm:mx-auto sm:my-4">
-  <h1 class="h1 my-8">Blog</h1>
-  <section class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+<div class="container mx-auto max-w-xl px-4 sm:px-0">
+  <h1 class="h1 my-8">Blog Posts</h1>
+  <section class="grid grid-cols-1 gap-4 sm:grid-cols-2">
     {#each data.posts as post}
       <PostCard {post} />
     {/each}

--- a/src/routes/blog/PostCard.svelte
+++ b/src/routes/blog/PostCard.svelte
@@ -9,10 +9,8 @@
   let { post }: Props = $props();
 </script>
 
-<a
-  href="blog/{post.slug}"
-  class="card prose h-auto min-h-[300px] max-w-full rounded-lg p-4 dark:prose-invert">
+<a href="blog/{post.slug}" class="card prose h-auto max-w-full rounded-lg p-4 dark:prose-invert">
   <h2>{post.title}</h2>
-  <p>{formatDate(post.date)}</p>
+  <p><em>{formatDate(post.date)}</em></p>
   <p>{post.description}</p>
 </a>

--- a/src/routes/blog/Sidenav.svelte
+++ b/src/routes/blog/Sidenav.svelte
@@ -8,15 +8,13 @@
   );
 </script>
 
-<nav class="list-nav p-4">
-  <div class="p-4 pt-0 font-bold">Posts</div>
-  <ul>
+<nav class="list-nav">
+  <ul class="m-0 p-0">
     {#each page.data.posts ?? [] as post}
       <li>
         <a
           href="/blog/{post.slug}"
-          class={classesActive(`/blog/${post.slug}`)}
-          style="white-space: pre-wrap">
+          class="{classesActive(`/blog/${post.slug}`)} whitespace-pre-wrap no-underline">
           {post.title}
         </a>
       </li>

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+  import { page } from '$app/state';
   import { formatDate } from '$lib/utils';
+  import Sidenav from '../Sidenav.svelte';
+  import Icon from '@iconify/svelte';
+  import { tocCrawler, popup, TableOfContents } from '@skeletonlabs/skeleton';
 
   let { data } = $props();
 </script>
@@ -9,15 +13,57 @@
   <title>{data.meta.title}</title>
   <meta property="og:type" content="article" />
   <meta property="og:title" content={data.meta.title} />
+  <!-- TODO: image -->
 </svelte:head>
+<div class="container mx-auto grid grid-cols-1 pt-6 lg:grid-cols-[200px_minmax(0px,_1fr)_200px]">
+  <!-- 100px leaves room for navbar -->
+  <aside class="sticky top-[100px] col-span-1 hidden h-screen scroll-mt-[100px] lg:block">
+    <div class="p-4 pt-0 font-bold">Posts</div>
+    <Sidenav />
+  </aside>
 
-<article class="prose mx-auto p-4 pt-12 dark:prose-invert">
-  <hgroup>
-    <h1>{data.meta.title}</h1>
-    <p class="italic">{formatDate(data.meta.date)}</p>
-  </hgroup>
+  <main class="col-span-1 space-y-4 px-8 py-0">
+    <article class="prose mx-auto mb-8 dark:prose-invert">
+      <hgroup>
+        <div class="flex items-center justify-between">
+          <span class="shrink-0 italic">{formatDate(data.meta.date)}</span>
+          <button
+            class="btn hover:variant-soft-primary lg:hidden"
+            use:popup={{ event: 'click', target: 'features' }}>
+            <span>Other posts</span>
+            <Icon icon="material-symbols:keyboard-arrow-down" />
+          </button>
+          <!-- popup -->
+          <div class="card w-60 p-2 shadow-xl" data-popup="features">
+            <Sidenav />
+          </div>
+        </div>
+        <h1>{data.meta.title}</h1>
+      </hgroup>
 
-  <div class="content">
-    <data.content />
-  </div>
-</article>
+      <div
+        class="content mb-8"
+        use:tocCrawler={{
+          mode: 'generate',
+          queryElements: 'h2',
+          // need IDs to be unique otherwise ToC won't update between pages
+          key: page.url.pathname,
+        }}>
+        <data.content />
+      </div>
+
+      <hr />
+      <a
+        href="https://github.com/tuckergordon/website/blob/main/src/posts/{page.params.slug}.md"
+        class="btn mb-4 p-0 text-primary-500 no-underline hover:underline"
+        target="_blank">
+        <Icon icon="material-symbols:edit" />
+        <span>Edit this page</span>
+      </a>
+    </article>
+  </main>
+
+  <aside class="sticky top-[100px] col-span-1 hidden h-screen scroll-mt-[100px] lg:block">
+    <TableOfContents>On The Page</TableOfContents>
+  </aside>
+</div>

--- a/src/styles/app.postcss
+++ b/src/styles/app.postcss
@@ -3,9 +3,18 @@
 @tailwind utilities;
 @tailwind variants;
 
-html,
+/* Need to change the scroll to be on body instead of document
+so that Skeleton TableOfContents scroll events trigger correctly */
+html {
+  height: 100%;
+  overflow: hidden; /* Prevent scrolling on the <html> element */
+}
+
 body {
-  @apply h-full overflow-hidden;
+  @apply bg-white dark:bg-surface-800;
+
+  height: 100vh; /* Full viewport height */
+  overflow-y: scroll; /* Enable vertical scrolling on the body */
 }
 
 /* Override the link styles that Skeleton's table of contents apply */


### PR DESCRIPTION
Updates the style/layout of the blog page (and some of the site in general) to use the latest from Skeleton.

The main change is dropping`AppShell` in favor of tailwind grid layouts.

Other feature improvements to blog page include:

- Repositioning date
- Adding TOC
- Adding links to other posts with a mobile menu
- Adding an edit link at the bottom of the post