### PR TITLE
Projects accordion

### DIFF
--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -1,14 +1,8 @@
 <script lang="ts">
   import * as config from '$lib/config';
+  import ProjectsAccordion from './ProjectsAccordion.svelte';
+  import ProjectsTable from './ProjectsTable.svelte';
   import projects from './projects.json';
-  import Icon from '@iconify/svelte';
-
-  function collapseYear(year: string | number) {
-    year = year.toString();
-    year = year.replace('Present', 'Pres.');
-    year = year.replace(/\b(\d{2})(\d{2})\b/g, "'$2");
-    return year;
-  }
 </script>
 
 <svelte:head>
@@ -18,62 +12,6 @@
 <div class="container px-4 pb-12 sm:mx-auto">
   <h1 class="h1 my-8">Projects</h1>
 
-  <div class="table-container">
-    <table class="table table-hover font-light">
-      <thead>
-        <tr>
-          <th>Year</th>
-          <th>Project</th>
-          <th class="hidden md:table-cell">Description</th>
-          <th class="hidden lg:table-cell">Built&nbsp;with</th>
-          <th class="hidden lg:table-cell">Deployed&nbsp;with</th>
-          <th class="hidden lg:table-cell">Made&nbsp;at</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each projects as project}
-          <tr>
-            <td class="hidden sm:table-cell">{project.year}</td>
-            <td class="sm:hidden">{collapseYear(project.year)}</td>
-            <td class="font-semibold">
-              {#if project.link}
-                <a
-                  href={project.link}
-                  target="_blank"
-                  rel="noopener"
-                  class="flex items-center justify-between hover:text-primary-500 dark:hover:text-secondary-500">
-                  {project.name}
-                  <Icon icon="mdi-external-link" class="inline"></Icon>
-                </a>
-              {:else}
-                {project.name}
-              {/if}
-            </td>
-            <td class="hidden md:table-cell">{project.description}</td>
-            <td class="hidden lg:table-cell">
-              {#if project.builtWith}
-                {#each project.builtWith as tech}
-                  <span
-                    class="variant-soft-secondary chip pointer-events-none m-1 dark:variant-ghost-secondary">
-                    {tech}
-                  </span>
-                {/each}
-              {/if}
-            </td>
-            <td class="hidden lg:table-cell">
-              {#if project.deployedWith}
-                {#each project.deployedWith as tech}
-                  <span
-                    class="variant-soft-primary chip pointer-events-none m-1 dark:variant-ghost-primary">
-                    {tech}
-                  </span>
-                {/each}
-              {/if}
-            </td>
-            <td class="hidden lg:table-cell">{project.madeAt}</td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
-  </div>
+  <ProjectsTable {projects} class="hidden md:block" />
+  <ProjectsAccordion {projects} class="block dark:bg-surface-700 md:hidden" />
 </div>

--- a/src/routes/projects/ProjectsAccordion.svelte
+++ b/src/routes/projects/ProjectsAccordion.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import Icon from '@iconify/svelte';
+  import { Accordion, AccordionItem } from '@skeletonlabs/skeleton';
+
+  let { projects, ...rest } = $props();
+
+  function collapseYear(year: string | number) {
+    year = year.toString();
+    year = year.replace('Present', 'Pres.');
+    year = year.replace(/\b(\d{2})(\d{2})\b/g, "'$2");
+    return year;
+  }
+</script>
+
+<Accordion autocollapse {...rest}>
+  {#each projects as project}
+    <AccordionItem>
+      <svelte:fragment slot="summary">
+        <div class="flex items-center justify-between">
+          <span class="font-semibold">{project.name}</span>
+          <span class="italic">{collapseYear(project.year)}</span>
+        </div></svelte:fragment>
+      <svelte:fragment slot="content">
+        <div class="px-2 font-light">
+          <div class="mb-4 font-normal">{project.description}</div>
+
+          {#if project.link}
+            <div class="mb-4">
+              Link:
+              <a
+                href={project.link}
+                target="_blank"
+                rel="noopener"
+                class="ml-2 hover:text-primary-500 dark:hover:text-secondary-500">
+                {project.link.replace('https://www.', '').replace('http://www.', '')}
+                <Icon icon="mdi-external-link" class="ml-1 inline"></Icon>
+              </a>
+            </div>
+          {/if}
+
+          {#if project.builtWith}
+            <div class="mb-4 flex">
+              <span class="mr-2 flex-shrink-0 pt-1">Built with:</span>
+              <div>
+                {#each project.builtWith as tech}
+                  <span
+                    class="variant-soft-secondary chip pointer-events-none m-1 dark:variant-ghost-secondary">
+                    {tech}
+                  </span>
+                {/each}
+              </div>
+            </div>
+          {/if}
+
+          {#if project.deployedWith}
+            <div class="flex">
+              <span class="mr-2 flex-shrink-0 pt-1">Deployed with:</span>
+              <div>
+                {#each project.deployedWith as tech}
+                  <span
+                    class="variant-soft-primary chip pointer-events-none m-1 dark:variant-ghost-primary">
+                    {tech}
+                  </span>
+                {/each}
+              </div>
+            </div>
+          {/if}
+        </div>
+      </svelte:fragment>
+    </AccordionItem>
+  {/each}
+</Accordion>

--- a/src/routes/projects/ProjectsTable.svelte
+++ b/src/routes/projects/ProjectsTable.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import Icon from '@iconify/svelte';
+
+  let { projects, ...rest } = $props();
+</script>
+
+<div class="table-container" {...rest}>
+  <table class="table table-hover font-light">
+    <thead>
+      <tr>
+        <th>Year</th>
+        <th>Project</th>
+        <th class="hidden md:table-cell">Description</th>
+        <th class="hidden lg:table-cell">Built&nbsp;with</th>
+        <th class="hidden lg:table-cell">Deployed&nbsp;with</th>
+        <th class="hidden lg:table-cell">Made&nbsp;at</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each projects as project}
+        <tr>
+          <td>{project.year}</td>
+          <td class="font-semibold">
+            {#if project.link}
+              <a
+                href={project.link}
+                target="_blank"
+                rel="noopener"
+                class="flex items-center justify-between hover:text-primary-500 dark:hover:text-secondary-500">
+                {project.name}
+                <Icon icon="mdi-external-link" class="inline"></Icon>
+              </a>
+            {:else}
+              {project.name}
+            {/if}
+          </td>
+          <td class="hidden md:table-cell">{project.description}</td>
+          <td class="hidden lg:table-cell">
+            {#if project.builtWith}
+              {#each project.builtWith as tech}
+                <span
+                  class="variant-soft-secondary chip pointer-events-none m-1 dark:variant-ghost-secondary">
+                  {tech}
+                </span>
+              {/each}
+            {/if}
+          </td>
+          <td class="hidden lg:table-cell">
+            {#if project.deployedWith}
+              {#each project.deployedWith as tech}
+                <span
+                  class="variant-soft-primary chip pointer-events-none m-1 dark:variant-ghost-primary">
+                  {tech}
+                </span>
+              {/each}
+            {/if}
+          </td>
+          <td class="hidden lg:table-cell">{project.madeAt}</td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>

--- a/src/routes/projects/projects.json
+++ b/src/routes/projects/projects.json
@@ -161,7 +161,7 @@
       "Make",
       "Adobe Xd"
     ],
-    "link": "https://www.boozallen.com/expertise/products/precog.html",
+    "link": "https://www.boozallen.com/expertise/products/precog",
     "deployedWith": ["Docker"]
   },
   {


### PR DESCRIPTION
On mobile, the table layout for projects was getting pretty squished and a lot of info was hidden entirely (e.g. the description and the `builtWith`/`deployedWith` lists).

So instead, on small screens I'm now showing an accordion view instead of a table. This lets users click into specific projects to get more info about them.