### PR TITLE
Bugfix: overlapping mobile bottom nav

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -165,7 +165,7 @@
   {/snippet}
 </Scroller>
 
-<section class="prose mx-auto my-12 px-4 dark:prose-invert sm:my-24">
+<section class="prose mx-auto my-12 px-4 dark:prose-invert sm:my-16">
   <p>
     I appreciate you taking the time to visit me on my little corner of the internet. If anything on
     this site makes you think "I'd like to chat with this guy," please reach out via any of the

--- a/src/routes/Footer.svelte
+++ b/src/routes/Footer.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <div
-  class="mt-16 border-t border-surface-500/10 bg-surface-50 text-xs dark:bg-surface-900 md:text-base">
+  class="mt-8 border-t border-surface-500/10 bg-surface-50 text-xs dark:bg-surface-900 md:text-base">
   <div class="mx-auto w-full max-w-7xl space-y-6 p-4 py-10">
     <section class="prose mx-auto text-center dark:prose-invert">
       <h3>I'd love to hear from you!</h3>

--- a/src/styles/app.postcss
+++ b/src/styles/app.postcss
@@ -3,18 +3,15 @@
 @tailwind utilities;
 @tailwind variants;
 
-/* Need to change the scroll to be on body instead of document
-so that Skeleton TableOfContents scroll events trigger correctly */
-html {
-  height: 100%;
-  overflow: hidden; /* Prevent scrolling on the <html> element */
+html,
+body {
+  /* By default, <html> and <body> may collapse vertically and not 
+  extend to full height of the viewport. This resets them  */
+  @apply h-full;
 }
 
 body {
   @apply bg-white dark:bg-surface-800;
-
-  height: 100vh; /* Full viewport height */
-  overflow-y: scroll; /* Enable vertical scrolling on the body */
 }
 
 /* Override the link styles that Skeleton's table of contents apply */


### PR DESCRIPTION
Using 100vh to set page height was causing bug on mobile where bottom nav bar would overlap page content. Using `height: 100%` (via `@apply h-full;`) instead.

Also adjusts some spacing around footer